### PR TITLE
Test fix for not removing style attribute

### DIFF
--- a/dist/big-ideas-text.js
+++ b/dist/big-ideas-text.js
@@ -1,5 +1,5 @@
 /*!
- * Big Ideas Text v0.4.1, 2016-02-02
+ * Big Ideas Text v0.4.1, 2016-07-10
  * https://github.com/kennethormandy/big-ideas-text
  * Copyright © 2011–2014 Zach Leatherman 
  * Copyright © 2016 Kenneth Ormandy (@kennethormandy)
@@ -394,9 +394,10 @@
 
     // No sure if this needs to be its own
     // forEach or can exist in one previous
-    forEach(children, function(child) {
-      child.removeAttribute('style');
-    });
+    // Removed for #4
+    // forEach(children, function(child) {
+    //   child.removeAttribute('style');
+    // });
 
     if( !BigIdeasText.DEBUG_MODE ) {
       c.parentNode.removeChild(c);

--- a/src/big-ideas-text.js
+++ b/src/big-ideas-text.js
@@ -386,9 +386,10 @@
 
     // No sure if this needs to be its own
     // forEach or can exist in one previous
-    forEach(children, function(child) {
-      child.removeAttribute('style');
-    });
+    // Removed for #4
+    // forEach(children, function(child) {
+    //   child.removeAttribute('style');
+    // });
 
     if( !BigIdeasText.DEBUG_MODE ) {
       c.parentNode.removeChild(c);


### PR DESCRIPTION
For #4. Don’t remove `style` attribute of `bigIdeasText-line`s.
